### PR TITLE
➖ Drop Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
 ]
 license = "MIT"
 requires-python = ">=3.7"


### PR DESCRIPTION
Pipeline on 3.11 is too slow.